### PR TITLE
v2.21.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "leagr",
-    "version": "2.21.6",
+    "version": "2.21.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "leagr",
-            "version": "2.21.6",
+            "version": "2.21.7",
             "dependencies": {
                 "async-mutex": "^0.5.0",
                 "canvas-confetti": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "leagr",
     "private": true,
-    "version": "2.21.6",
+    "version": "2.21.7",
     "description": "A SvelteKit application for managing a social (football) leagues.",
     "author": "Veli Gebrev",
     "type": "module",

--- a/src/lib/server/rankings.js
+++ b/src/lib/server/rankings.js
@@ -653,6 +653,8 @@ export class RankingsManager {
      * @param {number} awayScore - Away team score
      * @param {string} phase - Game phase ('league' or cup-related)
      * @param {Record<string, EloCarryOver>} eloCarryOver - ELO carry-over data from previous year
+     * @param homePenalties
+     * @param awayPenalties
      */
     updateEloRatingsForGame(
         playerTracker,

--- a/src/lib/server/teamGenerator.js
+++ b/src/lib/server/teamGenerator.js
@@ -1,5 +1,6 @@
 import { teamColours } from '$lib/shared/helpers.js';
 import { getNextNouns } from './nounPool.js';
+import { logger } from '$lib/server/logger.js';
 
 /** @typedef {import('../shared/types.js').LeagueSettings} LeagueSettings */
 /** @typedef {import('../shared/types.js').TeamGenerationSettings} TeamGenerationSettings */
@@ -1201,6 +1202,11 @@ class TeamGenerator {
 
         let bestTeams = null;
         let bestScore = Infinity; // Now tracking combined score instead of just ELO delta
+        /** @type {ReturnType<typeof this.calculateNormalizedScore> | null} */
+        let bestMetrics = null;
+        let pairingRejects = 0;
+        let eloRejects = 0;
+        let lastImprovementIteration = 0;
 
         let iteration;
         // Iterate to find the best balance of ELO balance and pairing variety
@@ -1210,6 +1216,11 @@ class TeamGenerator {
 
             // Check hard constraints first - reject if violated
             if (this.violatesHardConstraints(teams, hardConstraintLimit, hardEloDeltaLimit)) {
+                if (this.violatesHardConstraints(teams, hardConstraintLimit, null)) {
+                    pairingRejects++;
+                } else {
+                    eloRejects++;
+                }
                 continue; // Skip this iteration - hard constraints violated
             }
 
@@ -1220,10 +1231,13 @@ class TeamGenerator {
             if (totalNorm < bestScore) {
                 bestScore = totalNorm;
                 bestTeams = structuredClone(teams);
+                bestMetrics = metrics;
+                lastImprovementIteration = iteration;
             }
 
-            // Stop early if we achieve excellent balance across all metrics
-            if (iteration > 2000 && totalNorm <= 0.25) {
+            // Stop early after warmup if: score is excellent, or best hasn't improved for 1000 iterations
+            // (1000 iters ≈ 300 valid candidates at typical rejection rates — a reasonable convergence signal)
+            if (iteration > 2000 && (bestScore <= 0.25 || iteration - lastImprovementIteration > 1000)) {
                 break;
             }
         }
@@ -1248,7 +1262,9 @@ class TeamGenerator {
         }
 
         // If no valid teams found, fall back to generation without hard constraints
+        let fallbackUsed = false;
         if (!bestTeams) {
+            fallbackUsed = true;
             // Try one more time without hard constraints
             for (let fallbackIteration = 0; fallbackIteration < 5; fallbackIteration++) {
                 const teams = this.generateSeededTeamsIteration(config, teamNames, sortedPlayers);
@@ -1259,6 +1275,7 @@ class TeamGenerator {
                 if (totalNorm < bestScore) {
                     bestScore = totalNorm;
                     bestTeams = structuredClone(teams);
+                    bestMetrics = metrics;
                     break; // Take first reasonable solution
                 }
             }
@@ -1277,6 +1294,20 @@ class TeamGenerator {
             });
         }
 
+        this.logDrawInfo({
+            sortedPlayers,
+            numTeams,
+            config,
+            maxIterations,
+            iterationsUsed: iteration,
+            pairingRejects,
+            eloRejects,
+            bestMetrics,
+            fallbackUsed,
+            hardConstraintLimit,
+            hardEloDeltaLimit
+        });
+
         // Reconstruct draw history from final teams using the pot structure and snake draft
         if (this.recordHistory) {
             // Use original teamNames order (creation order) to match front-end display
@@ -1288,6 +1319,93 @@ class TeamGenerator {
         }
 
         return bestTeams;
+    }
+
+    /**
+     * Log a summary of a completed seeded draw — health signals, iteration stats, best norms.
+     * Emits warn if fallback fired or blocked-pair density is high, info for the standard summary,
+     * and debug for the per-player blocked breakdown.
+     */
+    logDrawInfo({
+        sortedPlayers,
+        numTeams,
+        config,
+        maxIterations,
+        iterationsUsed,
+        pairingRejects,
+        eloRejects,
+        bestMetrics,
+        fallbackUsed,
+        hardConstraintLimit,
+        hardEloDeltaLimit
+    }) {
+        const totalPairs = (sortedPlayers.length * (sortedPlayers.length - 1)) / 2;
+
+        // Count hard-blocked pairs in the current pool
+        let blockedCount = 0;
+        /** @type {Record<string, number>} */
+        const blockedPerPlayer = {};
+        if (this.teammateHistory) {
+            for (let i = 0; i < sortedPlayers.length; i++) {
+                for (let j = i + 1; j < sortedPlayers.length; j++) {
+                    const p1 = sortedPlayers[i];
+                    const p2 = sortedPlayers[j];
+                    const idx1 = this.teammateHistory.players.indexOf(p1);
+                    const idx2 = this.teammateHistory.players.indexOf(p2);
+                    if (
+                        idx1 >= 0 &&
+                        idx2 >= 0 &&
+                        this.teammateHistory.matrix[idx1][idx2] >= hardConstraintLimit
+                    ) {
+                        blockedCount++;
+                        blockedPerPlayer[p1] = (blockedPerPlayer[p1] || 0) + 1;
+                        blockedPerPlayer[p2] = (blockedPerPlayer[p2] || 0) + 1;
+                    }
+                }
+            }
+        }
+
+        const blockedPct = totalPairs > 0 ? (blockedCount / totalPairs) * 100 : 0;
+        const rejectTotal = pairingRejects + eloRejects;
+        const teamSize = config.teamSizes[0];
+
+        if (fallbackUsed) {
+            logger.warn(
+                `[teams] Fallback draw — pairing constraint unsatisfiable: ` +
+                    `${pairingRejects}/${maxIterations} iter rejected by pairing, ${eloRejects} by elo` +
+                    (this.teammateHistory
+                        ? ` | blocked pairs in pool: ${blockedCount}/${totalPairs} (${blockedPct.toFixed(1)}%)`
+                        : '')
+            );
+        } else if (blockedPct >= 8) {
+            logger.warn(
+                `[teams] High blocked-pair density: ${blockedCount}/${totalPairs} pairs in pool ` +
+                    `hard-blocked (${blockedPct.toFixed(1)}%). Constraint space is tightening.`
+            );
+        }
+
+        const m = bestMetrics;
+        logger.info(
+            `[teams] seeded ${sortedPlayers.length}p → ${numTeams}×${teamSize} | ` +
+                `${iterationsUsed}/${maxIterations} iter | ` +
+                `rejects: ${pairingRejects} pairing + ${eloRejects} elo (${rejectTotal} total) | ` +
+                (m
+                    ? `best: score=${m.totalNorm.toFixed(3)} elo=${Math.round(m.eloDelta)}pts(limit ${hardEloDeltaLimit}) pair=${m.pairNorm.toFixed(2)} spread=${m.spreadNorm.toFixed(2)} | `
+                    : '') +
+                `fallback=${fallbackUsed}`
+        );
+
+        if (this.teammateHistory) {
+            const topBlocked = Object.entries(blockedPerPlayer)
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 5)
+                .map(([name, count]) => `${name}×${count}`)
+                .join(' ');
+            logger.debug(
+                `[teams] blocked pairs: ${blockedCount}/${totalPairs} (${blockedPct.toFixed(1)}%)` +
+                    (topBlocked ? ` | most-blocked: ${topBlocked}` : '')
+            );
+        }
     }
 
     /**

--- a/src/lib/server/teamGenerator.js
+++ b/src/lib/server/teamGenerator.js
@@ -692,7 +692,7 @@ class TeamGenerator {
      */
     calculateNormalizedScore(teams, eloRange, hardEloDeltaLimit) {
         const W_ELO = 1.0;
-        const W_SPREAD = 0.7;
+        const W_SPREAD = 0.0; // Pot-seeding structurally prevents spread imbalance; norm never activates
         const W_PAIR = 1.3;
         const W_ATTACK = 0.8;
         const W_CONTROL = 0.8;
@@ -761,12 +761,15 @@ class TeamGenerator {
 
     /**
      * Calculate trait distribution balance across teams.
-     * Measures how evenly attack traits (isFinisher, isAttacker) and defence traits
-     * (isDefender, isShotStopper) are distributed. An "engine" player who holds
-     * multiple traits contributes to each relevant pool simultaneously.
+     * Scores each of the four traits independently (isFinisher, isAttacker, isDefender,
+     * isShotStopper) and returns their average. Traits with zero holders in the pool
+     * are skipped entirely so they don't dilute the score.
      *
-     * Returns 0 when all teams have the same trait counts (perfect balance),
-     * up to 1 for maximum imbalance. Returns 0 when no players have traits.
+     * Normalisation is pool-relative: the worst-case range for a trait with N holders
+     * across T teams is ~2× the ideal (N/T), so we divide range by max(1, idealPerTeam × 2).
+     * This gives a properly scaled 0–1 score regardless of how few players hold the trait.
+     *
+     * Returns 0 when no players have any traits (perfect balance by default).
      *
      * @param {TeamsMap} teams - Generated teams object
      * @returns {number} Trait balance score [0, 1] where lower is better
@@ -775,52 +778,38 @@ class TeamGenerator {
         const teamNames = Object.keys(teams);
         if (teamNames.length < 2) return 0;
 
-        const attackCounts = [];
-        const defenceCounts = [];
-        let totalTraitPlayers = 0;
+        const traitKeys = ['isFinisher', 'isAttacker', 'isDefender', 'isShotStopper'];
+        const clamp01 = (v) => Math.min(1, Math.max(0, v));
+        const traitScores = [];
 
-        for (const teamName of teamNames) {
-            const players = teams[teamName];
-            let attackCount = 0;
-            let defenceCount = 0;
+        for (const traitKey of traitKeys) {
+            const teamCounts = [];
+            let totalWithTrait = 0;
 
-            for (const playerName of players) {
-                let playerData = this.rankings?.players?.[playerName];
-                if (!playerData && this.previousYearRankings?.players?.[playerName]) {
-                    playerData = this.previousYearRankings.players[playerName];
+            for (const teamName of teamNames) {
+                let count = 0;
+                for (const playerName of teams[teamName]) {
+                    let playerData = this.rankings?.players?.[playerName];
+                    if (!playerData && this.previousYearRankings?.players?.[playerName]) {
+                        playerData = this.previousYearRankings.players[playerName];
+                    }
+                    if (playerData?.traits?.[traitKey]) count++;
                 }
-                const traits = playerData?.traits;
-                if (!traits) continue;
-
-                if (traits.isFinisher || traits.isAttacker) {
-                    attackCount++;
-                    totalTraitPlayers++;
-                }
-                if (traits.isDefender || traits.isShotStopper) {
-                    defenceCount++;
-                    totalTraitPlayers++;
-                }
+                teamCounts.push(count);
+                totalWithTrait += count;
             }
 
-            attackCounts.push(attackCount);
-            defenceCounts.push(defenceCount);
+            // Skip traits that no player in the pool has
+            if (totalWithTrait === 0) continue;
+
+            const range = Math.max(...teamCounts) - Math.min(...teamCounts);
+            const idealPerTeam = totalWithTrait / teamNames.length;
+            // Worst case: all holders on one team → range ≈ 2× ideal
+            traitScores.push(clamp01(range / Math.max(1, idealPerTeam * 2)));
         }
 
-        // No players have any traits — neutral score
-        if (totalTraitPlayers === 0) return 0;
-
-        const avgTeamSize =
-            Object.values(teams).reduce((s, p) => s + p.length, 0) / teamNames.length;
-        const normDivisor = Math.max(1, avgTeamSize);
-        const clamp01 = (v) => Math.min(1, Math.max(0, v));
-
-        const attackRange = Math.max(...attackCounts) - Math.min(...attackCounts);
-        const defenceRange = Math.max(...defenceCounts) - Math.min(...defenceCounts);
-
-        const attackScore = clamp01(attackRange / normDivisor);
-        const defenceScore = clamp01(defenceRange / normDivisor);
-
-        return (attackScore + defenceScore) / 2;
+        if (traitScores.length === 0) return 0;
+        return traitScores.reduce((s, v) => s + v, 0) / traitScores.length;
     }
 
     /**
@@ -1237,7 +1226,10 @@ class TeamGenerator {
 
             // Stop early after warmup if: score is excellent, or best hasn't improved for 1000 iterations
             // (1000 iters ≈ 300 valid candidates at typical rejection rates — a reasonable convergence signal)
-            if (iteration > 2000 && (bestScore <= 0.25 || iteration - lastImprovementIteration > 1000)) {
+            if (
+                iteration > 2000 &&
+                (bestScore <= 0.25 || iteration - lastImprovementIteration > 1000)
+            ) {
                 break;
             }
         }

--- a/src/lib/server/teamGenerator.js
+++ b/src/lib/server/teamGenerator.js
@@ -911,7 +911,12 @@ class TeamGenerator {
      * @returns {TeamsMap} Optimized teams object
      */
     optimizeTeamsWithSwaps(teams, sortedPlayers, options = {}) {
-        const { maxSwaps = 200, eloRange = null, hardEloDeltaLimit = null } = options;
+        const {
+            maxSwaps = 200,
+            eloRange = null,
+            hardEloDeltaLimit = null,
+            hardConstraintLimit = 4
+        } = options;
         if (!this.teammateHistory || !this.initialPots || this.initialPots.length === 0) {
             return teams; // Need history and pot structure for optimization
         }
@@ -985,6 +990,7 @@ class TeamGenerator {
 
                                 if (
                                     testMetrics.eloDelta <= effectiveHardEloDeltaLimit &&
+                                    !this.violatesHardConstraints(testTeams, hardConstraintLimit) &&
                                     (testMetrics.totalNorm < currentMetrics.totalNorm ||
                                         (testMetrics.totalNorm === currentMetrics.totalNorm &&
                                             testMetrics.eloDelta < currentMetrics.eloDelta))
@@ -1191,7 +1197,7 @@ class TeamGenerator {
         const hardEloDeltaLimit = Math.max(60, Math.floor(eloRange * 0.15));
 
         const maxIterations = 5000;
-        const hardConstraintLimit = 3; // Completely reject teams with pairs having 4+ previous pairings
+        const hardConstraintLimit = 4; // Completely reject teams with pairs having 4+ previous pairings
 
         let bestTeams = null;
         let bestScore = Infinity; // Now tracking combined score instead of just ELO delta
@@ -1266,7 +1272,8 @@ class TeamGenerator {
         if (this.teammateHistory && Object.keys(bestTeams).length >= 2) {
             bestTeams = this.optimizeTeamsWithSwaps(bestTeams, sortedPlayers, {
                 eloRange,
-                hardEloDeltaLimit
+                hardEloDeltaLimit,
+                hardConstraintLimit
             });
         }
 

--- a/src/lib/server/teammateHistory.js
+++ b/src/lib/server/teammateHistory.js
@@ -17,14 +17,17 @@ export class TeammateHistoryTracker {
      * @param {string} leagueId - League identifier
      * @param {number | null} fileLimit - Max files to return. Default 70 covers the worst case for a
      *   10-session window (10 weeks × 7 days). Pass null for no limit.
+     * @param {string | null} beforeDate - Exclude files on or after this date (YYYY-MM-DD).
+     *   Pass the current session date to prevent redraws from contaminating their own history.
      * @returns {Promise<string[]>} Array of session file paths
      */
-    async getSessionFiles(leagueId, fileLimit = 70) {
+    async getSessionFiles(leagueId, fileLimit = 70, beforeDate = null) {
         const leaguePath = join(this.leagueDataPath, leagueId);
         const files = await readdir(leaguePath);
 
         const sorted = files
             .filter((file) => file.match(/^\d{4}-\d{2}-\d{2}\.json$/))
+            .filter((file) => !beforeDate || file < `${beforeDate}.json`)
             .sort((a, b) => b.localeCompare(a)); // Sort by date descending (newest first)
 
         return (fileLimit != null ? sorted.slice(0, fileLimit) : sorted).map((file) =>
@@ -84,11 +87,12 @@ export class TeammateHistoryTracker {
     /**
      * Build teammate history matrix from recent sessions
      * @param {string} leagueId - League identifier
-     * @param {number} sessionLimit - Maximum number of recent sessions to include (default: 12)
+     * @param {number} sessionLimit - Maximum number of recent sessions to include (default: 10)
+     * @param {string | null} beforeDate - Exclude files on or after this date (YYYY-MM-DD).
      * @returns {Promise<Object>} Teammate history data
      */
-    async buildTeammateHistory(leagueId, sessionLimit = 10) {
-        const sessionFiles = await this.getSessionFiles(leagueId);
+    async buildTeammateHistory(leagueId, sessionLimit = 10, beforeDate = null) {
+        const sessionFiles = await this.getSessionFiles(leagueId, 70, beforeDate);
         const allPlayers = new Set();
         const pairCounts = new Map();
 
@@ -166,11 +170,12 @@ export class TeammateHistoryTracker {
     /**
      * Update teammate history for a league (main function)
      * @param {string} leagueId - League identifier
-     * @param {number} sessionLimit - Maximum number of recent sessions to include (default: 12)
+     * @param {number} sessionLimit - Maximum number of recent sessions to include (default: 10)
+     * @param {string | null} beforeDate - Exclude files on or after this date (YYYY-MM-DD).
      * @returns {Promise<{historyData: Object}>} Updated history data
      */
-    async updateTeammateHistory(leagueId, sessionLimit = 10) {
-        const historyData = await this.buildTeammateHistory(leagueId, sessionLimit);
+    async updateTeammateHistory(leagueId, sessionLimit = 10, beforeDate = null) {
+        const historyData = await this.buildTeammateHistory(leagueId, sessionLimit, beforeDate);
         await this.saveTeammateHistory(leagueId, historyData);
         return { historyData };
     }

--- a/src/lib/server/teammateHistory.js
+++ b/src/lib/server/teammateHistory.js
@@ -13,21 +13,23 @@ export class TeammateHistoryTracker {
     }
 
     /**
-     * Get all session files for a league (limited to recent sessions)
+     * Get all session files for a league, sorted by date descending
      * @param {string} leagueId - League identifier
-     * @param {number} sessionLimit - Maximum number of recent sessions to include (default: 12)
+     * @param {number | null} fileLimit - Max files to return. Default 70 covers the worst case for a
+     *   10-session window (10 weeks × 7 days). Pass null for no limit.
      * @returns {Promise<string[]>} Array of session file paths
      */
-    async getSessionFiles(leagueId, sessionLimit = 12) {
+    async getSessionFiles(leagueId, fileLimit = 70) {
         const leaguePath = join(this.leagueDataPath, leagueId);
         const files = await readdir(leaguePath);
 
-        // Filter for date files (YYYY-MM-DD.json format) and sort by date descending
-        return files
+        const sorted = files
             .filter((file) => file.match(/^\d{4}-\d{2}-\d{2}\.json$/))
-            .sort((a, b) => b.localeCompare(a)) // Sort by date descending (newest first)
-            .slice(0, sessionLimit) // Take only the most recent sessions
-            .map((file) => join(leaguePath, file));
+            .sort((a, b) => b.localeCompare(a)); // Sort by date descending (newest first)
+
+        return (fileLimit != null ? sorted.slice(0, fileLimit) : sorted).map((file) =>
+            join(leaguePath, file)
+        );
     }
 
     /**
@@ -85,17 +87,23 @@ export class TeammateHistoryTracker {
      * @param {number} sessionLimit - Maximum number of recent sessions to include (default: 12)
      * @returns {Promise<Object>} Teammate history data
      */
-    async buildTeammateHistory(leagueId, sessionLimit = 12) {
-        const sessionFiles = await this.getSessionFiles(leagueId, sessionLimit);
+    async buildTeammateHistory(leagueId, sessionLimit = 10) {
+        const sessionFiles = await this.getSessionFiles(leagueId);
         const allPlayers = new Set();
         const pairCounts = new Map();
 
-        // Process each session
+        // Process sessions, counting only those with actual teams toward the limit
+        let sessionsWithTeams = 0;
         for (const filePath of sessionFiles) {
+            if (sessionsWithTeams >= sessionLimit) break;
+
             const sessionData = await this.loadSessionData(filePath);
             if (!sessionData) continue;
 
             const pairs = this.extractTeammatePairs(sessionData);
+            if (pairs.length === 0) continue; // skip sessions with no teams
+
+            sessionsWithTeams++;
 
             // Track all unique players
             pairs.forEach(([player1, player2]) => {
@@ -135,7 +143,7 @@ export class TeammateHistoryTracker {
             leagueId,
             players: playerList,
             matrix,
-            totalSessions: sessionFiles.length,
+            totalSessions: sessionsWithTeams,
             lastUpdated: new Date().toISOString(),
             metadata: {
                 totalPlayers: playerCount,
@@ -161,7 +169,7 @@ export class TeammateHistoryTracker {
      * @param {number} sessionLimit - Maximum number of recent sessions to include (default: 12)
      * @returns {Promise<{historyData: Object}>} Updated history data
      */
-    async updateTeammateHistory(leagueId, sessionLimit = 12) {
+    async updateTeammateHistory(leagueId, sessionLimit = 10) {
         const historyData = await this.buildTeammateHistory(leagueId, sessionLimit);
         await this.saveTeammateHistory(leagueId, historyData);
         return { historyData };

--- a/src/routes/api/teams/+server.js
+++ b/src/routes/api/teams/+server.js
@@ -155,7 +155,11 @@ export const POST = async ({ request, url, locals }) => {
         if (method === 'seeded') {
             try {
                 const historyTracker = createTeammateHistoryTracker();
-                const { historyData } = await historyTracker.updateTeammateHistory(leagueId, 10, dateValidation.date);
+                const { historyData } = await historyTracker.updateTeammateHistory(
+                    leagueId,
+                    10,
+                    dateValidation.date
+                );
                 teammateHistory = historyData;
             } catch (error) {
                 console.warn(

--- a/src/routes/api/teams/+server.js
+++ b/src/routes/api/teams/+server.js
@@ -155,7 +155,7 @@ export const POST = async ({ request, url, locals }) => {
         if (method === 'seeded') {
             try {
                 const historyTracker = createTeammateHistoryTracker();
-                const { historyData } = await historyTracker.updateTeammateHistory(leagueId, 10);
+                const { historyData } = await historyTracker.updateTeammateHistory(leagueId, 10, dateValidation.date);
                 teammateHistory = historyData;
             } catch (error) {
                 console.warn(

--- a/src/routes/api/teams/+server.js
+++ b/src/routes/api/teams/+server.js
@@ -155,7 +155,7 @@ export const POST = async ({ request, url, locals }) => {
         if (method === 'seeded') {
             try {
                 const historyTracker = createTeammateHistoryTracker();
-                const { historyData } = await historyTracker.updateTeammateHistory(leagueId, 12);
+                const { historyData } = await historyTracker.updateTeammateHistory(leagueId, 10);
                 teammateHistory = historyData;
             } catch (error) {
                 console.warn(


### PR DESCRIPTION
Team Generation Tweaks:

- Looser pairing constraints (3 pairings in 12 weeks was mathematically impossible with the group size, changed to 4 pairings in 10 weeks) 
- Spread norm no-op (never activates anyway)
- Trait norm now calculated from each trait individually instead of attack/defend buckets
- Logging of team draws to help with debugging and statistical quirks affecting the algorithm